### PR TITLE
Implement host-specific i3 settings and reconcile differences between systems

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -16,7 +16,7 @@ set $mod Mod4
 font pango:Sauce Code Pro Nerd Font 14
 
 # Don't show window titles
-default_border pixel 2
+default_border pixel 3
 
 # Use Gaps
 gaps inner 5px
@@ -58,12 +58,6 @@ bindsym XF86AudioPlay exec playerctl play-pause
 # Printscreen
 bindsym --release Print exec gnome-screenshot
 bindsym --release Shift+Print exec gnome-screenshot -a
-
-# Backlight keys
-bindsym XF86MonBrightnessUp exec --no-startup-id light -A 5 \
-&& notify-send "Backlight Level" $(light -G) -h string:x-canonical-private-synchronous:backlight
-bindsym XF86MonBrightnessDown exec --no-startup-id light -U 5 \
-&& notify-send "Backlight Level" $(light -G) -h string:x-canonical-private-synchronous:backlight
 
 # Use Mouse+$mod to drag floating windows to their wanted position
 floating_modifier $mod

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -210,3 +210,6 @@ mode "resize" {
 }
 
 bindsym $mod+r mode "resize"
+
+# Include host-specific config
+include ~/.config/i3/`hostname`.conf

--- a/.config/i3/nelson.conf
+++ b/.config/i3/nelson.conf
@@ -1,0 +1,6 @@
+# Backlight keys
+bindsym XF86MonBrightnessUp exec --no-startup-id light -A 5 \
+&& notify-send "Backlight Level" $(light -G) -h string:x-canonical-private-synchronous:backlight
+bindsym XF86MonBrightnessDown exec --no-startup-id light -U 5 \
+&& notify-send "Backlight Level" $(light -G) -h string:x-canonical-private-synchronous:backlight
+

--- a/.config/i3/toggle_workspace.sh
+++ b/.config/i3/toggle_workspace.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 #toggle between these workspaces:
-workspace_a=3
-workspace_b=4
+workspace_a=4
+workspace_b=3
 
 #get focused
 focused_workspace=`i3-msg -t get_workspaces | jq '.[] | select(.focused==true)' | jq .num`

--- a/.config/polybar/config.ini
+++ b/.config/polybar/config.ini
@@ -80,7 +80,7 @@ module-margin = 1
 separator = |
 separator-foreground = ${colors.flamingo}
 
-font-0 = SauceCodePro NF:style=Regular=12;6
+font-0 = Hack Nerd Font:style=Regular=12;6
 
 modules-left = xworkspaces xwindow
 modules-right = systray memory cpu wlan battery pulseaudio-control date

--- a/.profile
+++ b/.profile
@@ -36,3 +36,7 @@ export MINICOM
 source /home/mike/compile/golioth-zephyr-workspace/zephyr/scripts/west_commands/completion/west-completion.bash
 
 . "$HOME/.cargo/env"
+
+if [ -d "$HOME/adb-fastboot/platform-tools" ] ; then
+ export PATH="$HOME/adb-fastboot/platform-tools:$PATH"
+fi


### PR DESCRIPTION
Nelson and Krusty have diverged because of different i3 implementation between systems. This commit abstracts Nelson-specific i3 config into a nelson.conf and reconciles differences to the two system may once again use the same branch/commit.