### PR TITLE
Add host-specific config for Hyprland

### DIFF
--- a/.config/fish/functions/fish_user_key_bindings.fish
+++ b/.config/fish/functions/fish_user_key_bindings.fish
@@ -1,4 +1,9 @@
 function fish_user_key_bindings
   fish_vi_key_bindings
+
+  # Use k-j as escape
   bind -M insert -m default kj backward-char force-repaint
+
+  # timeout for key sequences (don't wait forever when 'k' was last key)
+  set -g fish_sequence_key_delay_ms 200
 end

--- a/dotfiles/.config/hypr/conf/custom-krusty.conf
+++ b/dotfiles/.config/hypr/conf/custom-krusty.conf
@@ -1,1 +1,10 @@
 # Config unique to Krusty
+
+render {
+    explicit_sync = 1
+    explicit_sync_kms = 1
+    direct_scanout = no
+}
+
+monitor=DVI-D-1,1920x1080,1920x0,1
+monitor=HDMI-A-1,1920x1080,0x0,1

--- a/dotfiles/.config/hypr/conf/custom-krusty.conf
+++ b/dotfiles/.config/hypr/conf/custom-krusty.conf
@@ -1,0 +1,1 @@
+# Config unique to Krusty

--- a/dotfiles/.config/hypr/conf/custom-nelson.conf
+++ b/dotfiles/.config/hypr/conf/custom-nelson.conf
@@ -1,0 +1,1 @@
+# Config unique to Nelson

--- a/dotfiles/.config/hypr/conf/custom.conf
+++ b/dotfiles/.config/hypr/conf/custom.conf
@@ -42,6 +42,9 @@ bind = $mainMod, S, swapsplit                                       # Swapsplit
 bind = $mainMod, D, exec, pkill rofi || rofi -show drun -replace -i # Open application launcher
 bind = , xf86poweroff , exec, hyprlock                              # Power button locks screen
 bind = , F12, exec, $HYPRSCRIPTS/toggle_terminal.sh # Toggle between workspace 3/4
+bind = SHIFT, PRINT, exec, grimblast copy area                                            # Take a screenshot of area
+bind = , PRINT, exec, grimblast save screen                                               # Take a screenshot of active screen
+
 
 # Launch apps
 exec-once = [workspace 1 silent] slack

--- a/dotfiles/.config/hypr/conf/custom.conf
+++ b/dotfiles/.config/hypr/conf/custom.conf
@@ -52,3 +52,7 @@ exec-once = [workspace 4 silent] kitty
 misc {
   focus_on_activate=true
 }
+
+# Import settings unique to this computer
+# This file will be symlinked by the fish shell. See ~/dotfiles/.config/fish/config.fish
+source = ~/.config/hypr/conf/custom-by-hostname.conf

--- a/dotfiles/.config/hypr/conf/keyboard.conf
+++ b/dotfiles/.config/hypr/conf/keyboard.conf
@@ -1,0 +1,35 @@
+# -----------------------------------------------------
+# Keyboard Layout
+# https://wiki.hyprland.org/Configuring/Variables/#input
+# -----------------------------------------------------
+input {
+    kb_layout = us
+    kb_variant = 
+    kb_model =
+    kb_options =
+    numlock_by_default = true
+    mouse_refocus = false
+
+    # For United States
+    # kb_layout = us
+    # kb_variant = intl
+    # kb_model = pc105
+    # kb_options =
+
+    follow_mouse = 1
+    touchpad {
+        # for desktop
+        natural_scroll = false
+
+        # for laptop
+        # natural_scroll = yes
+        middle_button_emulation = true
+        clickfinger_behavior = true
+        scroll_factor = 1.0  # Touchpad scroll factor
+    }
+    sensitivity = 0 # Pointer speed: -1.0 - 1.0, 0 means no modification.
+}
+
+gestures {
+    workspace_swipe = true
+}

--- a/dotfiles/.config/hypr/hypridle.conf
+++ b/dotfiles/.config/hypr/hypridle.conf
@@ -1,0 +1,35 @@
+general {
+    lock_cmd = pidof hyprlock || hyprlock       # avoid starting multiple hyprlock instances.
+    # lock_cmd = playerctl --all-players pause && pidof hyprlock || hyprlock  # pause all system audio and avoid starting multiple hyprlock instances.
+    before_sleep_cmd = loginctl lock-session    # lock before suspend.
+    after_sleep_cmd = hyprctl dispatch dpms on  # to avoid having to press a key twice to turn on the display.
+}
+
+listener {
+    timeout = 480                                # 8min.
+    on-timeout = brightnessctl -s set 10         # set monitor backlight to minimum, avoid 0 on OLED monitor.
+    on-resume = brightnessctl -r                 # monitor backlight restore.
+}
+
+# turn off keyboard backlight, comment out this section if you dont have a keyboard backlight.
+# listener {
+#     timeout = 480                                          # 8min.
+#     on-timeout = brightnessctl -sd rgb:kbd_backlight set 0 # turn off keyboard backlight.
+#     on-resume = brightnessctl -rd rgb:kbd_backlight        # turn on keyboard backlight.
+# }
+
+listener {
+    timeout = 600                                 # 10min
+    on-timeout = loginctl lock-session            # lock screen when timeout has passed
+}
+
+listener {
+    timeout = 660                                                     # 11min
+    on-timeout = hyprctl dispatch dpms off                            # screen off when timeout has passed
+    on-resume = hyprctl dispatch dpms on && brightnessctl -r          # screen on when activity is detected after timeout has fired.
+}
+
+listener {
+    timeout = 1800
+    on-timeout = [ $HOSTNAME == "krusty" ] || systemctl suspend                # suspend pc
+}

--- a/dotfiles/.config/hypr/hyprland.conf
+++ b/dotfiles/.config/hypr/hyprland.conf
@@ -1,0 +1,78 @@
+#  _   _                  _                 _
+# | | | |_   _ _ __  _ __| | __ _ _ __   __| |
+# | |_| | | | | '_ \| '__| |/ _` | '_ \ / _` |
+# |  _  | |_| | |_) | |  | | (_| | | | | (_| |
+# |_| |_|\__, | .__/|_|  |_|\__,_|_| |_|\__,_|
+#        |___/|_|
+#
+# -----------------------------------------------------
+# IMPORTANT: Don't overwrite ML4W configuration.
+# Create your own custom configuration variation instead.
+# https://github.com/mylinuxforwork/dotfiles/wiki/Configuration-Variations
+
+# Import Hyprland settings unique to this computer
+# This automatically symlinks the correct file based on hostname
+exec-once = ln -s "./custom-$HOSTNAME.conf" ~/dotfiles/.config/hypr/conf/custom-by-hostname.conf &> /dev/null
+
+# -----------------------------------------------------
+# Monitor
+# -----------------------------------------------------
+source = ~/.config/hypr/conf/monitor.conf
+
+# -----------------------------------------------------
+# Cursor
+# -----------------------------------------------------
+source = ~/.config/hypr/conf/cursor.conf
+
+# -----------------------------------------------------
+# Environment
+# -----------------------------------------------------
+source = ~/.config/hypr/conf/environment.conf
+
+# -----------------------------------------------------
+# Keyboard
+# -----------------------------------------------------
+source = ~/.config/hypr/conf/keyboard.conf
+
+# -----------------------------------------------------
+# Load pywal color file
+# -----------------------------------------------------
+source = ~/.config/hypr/colors.conf
+$color8 = $on_primary_fixed
+$color11 = $on_surface
+
+# -----------------------------------------------------
+# Autostart
+# -----------------------------------------------------
+source = ~/.config/hypr/conf/autostart.conf
+
+# -----------------------------------------------------
+# Load configuration files
+# -----------------------------------------------------
+source = ~/.config/hypr/conf/window.conf
+source = ~/.config/hypr/conf/decoration.conf
+source = ~/.config/hypr/conf/layout.conf
+source = ~/.config/hypr/conf/workspace.conf
+source = ~/.config/hypr/conf/misc.conf
+source = ~/.config/hypr/conf/keybinding.conf
+source = ~/.config/hypr/conf/windowrule.conf
+
+# -----------------------------------------------------
+# Animation
+# -----------------------------------------------------
+source = ~/.config/hypr/conf/animation.conf
+
+# -----------------------------------------------------
+# Environment for xdg-desktop-portal-hyprland
+# -----------------------------------------------------
+exec-once=dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
+
+# -----------------------------------------------------
+# ML4W Configuration
+# -----------------------------------------------------
+source = ~/.config/hypr/conf/ml4w.conf
+
+# -----------------------------------------------------
+# Custom
+# -----------------------------------------------------
+source = ~/.config/hypr/conf/custom.conf


### PR DESCRIPTION
This PR adds host specific Hyprland configuration. These files are tracked separately, then symlinked based on the hostname when Hyprland starts up.